### PR TITLE
Fixes link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Filecoin Wallaby Testnet Documentation
 
-please check https://kb.factor8.io/e/en/docs/fil/wallabynet
+please check https://kb.factor8.io/en/docs/fil/wallabynet


### PR DESCRIPTION
The original link lead to an error page:

![image](https://user-images.githubusercontent.com/9611008/201376325-04d1dbcd-c90a-472d-a3fb-d2bc44917778.png)

This PR removes two extra characters from the URL.